### PR TITLE
Add ChatGPT summary to `gpt-summary` chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Directories
 **/node_modules/
-**/sketches/*
+**/sketches/
 
 # OS-specific files
 **/.DS_Store

--- a/gpt-summary/public/css/main.css
+++ b/gpt-summary/public/css/main.css
@@ -1,3 +1,22 @@
 body {
-  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI","Noto Sans",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";line-height: 1.625;
+}
+
+main {
+  margin-inline: auto;
+  width: 67rem;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  margin: 0;
+}
+
+main * + * {
+  margin-top: 1rem;
 }

--- a/gpt-summary/public/css/main.css
+++ b/gpt-summary/public/css/main.css
@@ -20,3 +20,13 @@ p {
 main * + * {
   margin-top: 1rem;
 }
+
+/* SVG adjustments */
+g.yAxis .tick:last-of-type text {
+  font-weight: bold;
+}
+
+line.yGridLine {
+  transform: translateX(-0.5rem);
+}
+

--- a/gpt-summary/public/css/main.css
+++ b/gpt-summary/public/css/main.css
@@ -17,6 +17,10 @@ p {
   margin: 0;
 }
 
+a {
+  color: #0000cd;
+}
+
 main * + * {
   margin-top: 1rem;
 }
@@ -28,5 +32,13 @@ g.yAxis .tick:last-of-type text {
 
 line.yGridLine {
   transform: translateX(-0.5rem);
+}
+
+#d3-chart-header span {
+  color: #727272;
+  display: block;
+  font-size: 0.75em;
+  font-weight: normal;
+  line-height: 1.25;
 }
 

--- a/gpt-summary/public/index.html
+++ b/gpt-summary/public/index.html
@@ -11,8 +11,10 @@
 
 <body>
   <main>
-    <h1>ChatGPT chart summary</h1>
-    <p>This demo uses D3.js to draw an SVG chart and GPT 3.5-turbo to write a summary of the visual price data.</p>
+    <div>
+      <h1>ChatGPT chart summary</h1>
+      <p>This demo uses D3.js to draw an SVG chart and GPT 3.5-turbo to write a summary of the visual price data.</p>
+    </div>
     <div aria-labelledby="d3-chart-header" id="d3-chart-container" role="region">
       <h2 id="d3-chart-header">Apple ($AAPL) historical price</h2>
     </div>

--- a/gpt-summary/public/index.html
+++ b/gpt-summary/public/index.html
@@ -15,12 +15,15 @@
       <h1>ChatGPT chart summary</h1>
       <p>This demo uses D3.js to draw an SVG chart and GPT 3.5-turbo to write a summary of the visual price data.</p>
     </div>
-    <div aria-labelledby="d3-chart-header" id="d3-chart-container" role="region">
-      <h2 id="d3-chart-header">Apple ($AAPL) historical price</h2>
+    <div aria-labelledby="d3-chart-header" id="combined-chart-wrapper" role="region">
+      <h2 id="d3-chart-header">
+        Apple historical price
+        <span>AAPL: NASDAQ </span>
+      </h2>
+      <div id="d3-chart-container"></div>
+      <div id="gpt-response-container"></div>
     </div>
-    <div id="gpt-response-container"></div>
   </main>
-
 
   <!-- Include the D3.js lib -->
   <script src="https://d3js.org/d3.v7.min.js"></script>

--- a/gpt-summary/public/index.html
+++ b/gpt-summary/public/index.html
@@ -10,9 +10,15 @@
 </head>
 
 <body>
-  <h1>Hey ma, it's me!</h1>
-  <p>I'm on TV!</p>
-  <div id="line-chart-container"></div>
+  <main>
+    <h1>ChatGPT chart summary</h1>
+    <p>This demo uses D3.js to draw an SVG chart and GPT 3.5-turbo to write a summary of the visual price data.</p>
+    <div aria-labelledby="d3-chart-header" id="d3-chart-container" role="region">
+      <h2 id="d3-chart-header">Apple ($AAPL) historical price</h2>
+    </div>
+    <div id="gpt-response-container"></div>
+  </main>
+
 
   <!-- Include the D3.js lib -->
   <script src="https://d3js.org/d3.v7.min.js"></script>

--- a/gpt-summary/public/js/lineChart.js
+++ b/gpt-summary/public/js/lineChart.js
@@ -20,7 +20,7 @@ const y = d3.scaleLinear().range([height, 0]);
 
 // Create the SVG element and append it to the chart container
 const svg = d3
-  .select("#line-chart-container")
+  .select("#d3-chart-container")
   .append("svg")
   .attr("width", width + margin.left + margin.right)
   .attr("height", height + margin.top + margin.bottom)

--- a/gpt-summary/public/js/lineChart.js
+++ b/gpt-summary/public/js/lineChart.js
@@ -6,12 +6,12 @@
 
 // Set up dimensions and margins for my chart
 const margin = {
-  top: 50,
-  right: 30,
-  bottom: 60,
-  left: 90,
+  top: 48,
+  right: 64,
+  bottom: 64,
+  left: 32,
 };
-const width = 1066 - margin.left - margin.right;
+const width = 1072 - margin.left - margin.right;
 const height = 600 - margin.top - margin.bottom;
 
 // Set up the x and y scales

--- a/gpt-summary/public/js/lineChart.js
+++ b/gpt-summary/public/js/lineChart.js
@@ -56,16 +56,30 @@ y.domain([floor, ceiling]);
 // Add the x-axis
 svg
   .append("g")
-  .attr("transform", `translate(0,${height})`)
+  .attr("transform", `translate(0, ${height})`)
   .call(
     d3
       .axisBottom(x)
-      .ticks(d3.timeDay.every(3))
+      .ticks(d3.timeDay.every(4))
       .tickFormat(d3.timeFormat("%b %d"))
   );
 
 // Add the y-axis
-svg.append("g").call(d3.axisLeft(y));
+svg
+  .append("g")
+  .attr("transform", `translate(${width}, 0)`)
+  .call(
+    d3
+      .axisRight(y)
+      .ticks(5)
+      .tickFormat((d, i) => {
+        console.log(i);
+        if (i === 4) {
+          return `${d} USD`;
+        }
+        return d;
+      })
+  );
 
 // Add the points for each price
 svg

--- a/gpt-summary/public/js/lineChart.js
+++ b/gpt-summary/public/js/lineChart.js
@@ -2,15 +2,25 @@
  * DataVizDad YouTube
  * Create Beautiful Line Charts with D3 - D3.js Beginner's Guide
  * https://www.youtube.com/watch?v=g5bp02-CRAc
+ * https://www.youtube.com/watch?v=Wk8pIxcidv8
  */
 
-// Set up dimensions and margins for my chart
-const margin = {
-  top: 48,
-  right: 64,
-  bottom: 64,
-  left: 32,
+const cssConf = {
+  color: {
+    chartLine: "#157bcc",
+    trendLine: "#ff7f50",
+    gridGray: "#e0e0e0",
+    labelGray: "#727272",
+  },
+  margin: {
+    top: 48,
+    right: 80,
+    bottom: 64,
+    left: 8,
+  },
 };
+
+const { color, margin } = cssConf;
 const width = 1072 - margin.left - margin.right;
 const height = 600 - margin.top - margin.bottom;
 
@@ -56,42 +66,79 @@ y.domain([floor, ceiling]);
 // Add the x-axis
 svg
   .append("g")
-  .attr("transform", `translate(0, ${height})`)
+  .attr("class", "xAxis")
+  .attr("transform", `translate(-8, ${height})`)
+  .style("font-size", "0.825rem")
+  .style("font-weight", "bold")
   .call(
     d3
       .axisBottom(x)
       .ticks(d3.timeDay.every(4))
       .tickFormat(d3.timeFormat("%b %d"))
-  );
+      .tickPadding(10)
+  )
+  .call((g) => g.select(".domain").remove())
+  .selectAll(".tick line")
+  .style("stroke-opacity", 0);
 
 // Add the y-axis
 svg
   .append("g")
+  .attr("class", "yAxis")
   .attr("transform", `translate(${width}, 0)`)
+  .style("font-size", "0.825rem")
   .call(
     d3
       .axisRight(y)
       .ticks(5)
       .tickFormat((d, i) => {
-        console.log(i);
         if (i === 4) {
           return `${d} USD`;
         }
         return d;
       })
-  );
+      .tickPadding(10)
+  )
+  .call((g) => g.select(".domain").remove())
+  .selectAll(".tick line")
+  .style("stroke-opacity", 0);
 
-// Add the points for each price
+// Update the text color
+svg.selectAll(".tick text").attr("fill", color.labelGray);
+
+// Add the vertical grid lines
 svg
-  .append("g")
-  .selectAll("dot")
-  .data(dataset)
-  .enter()
-  .append("circle")
-  .attr("cx", (d) => x(d.date))
-  .attr("cy", (d) => y(d.value))
-  .attr("r", 4)
-  .style("fill", "steelblue");
+  .selectAll("xGrid")
+  .data(x.ticks(d3.timeDay.every(4)))
+  .join("line")
+  .attr("class", "yGridLine")
+  .attr("x1", (d) => x(d))
+  .attr("x2", (d) => x(d))
+  .attr("y1", 0)
+  .attr("y2", height)
+  .attr("stroke", color.gridGray)
+  .attr("stroke-width", 1);
+
+// Add the horizontal grid lines
+svg
+  .selectAll("yGrid")
+  .data(y.ticks(5))
+  .join("line")
+  .attr("x1", 0)
+  .attr("x2", width)
+  .attr("y1", (d) => y(d))
+  .attr("y2", (d) => y(d))
+  .attr("stroke", color.gridGray)
+  .attr("stroke-width", 1);
+
+// Add the trendline
+svg
+  .append("line")
+  .attr("x1", x(dataset[1].date))
+  .attr("x2", width)
+  .attr("y1", y(dataset[1].value))
+  .attr("y2", y(dataset[dataset.length - 1].value))
+  .attr("stroke", color.trendLine);
 
 // Create the line generator
 const line = d3
@@ -104,6 +151,18 @@ svg
   .append("path")
   .datum(dataset)
   .attr("fill", "none")
-  .attr("stroke", "steelblue")
-  .attr("stroke-width", 2)
+  .attr("stroke", color.chartLine)
+  .attr("stroke-width", 3)
   .attr("d", line);
+
+// Add the dot for each price
+svg
+  .append("g")
+  .selectAll("dot")
+  .data(dataset)
+  .enter()
+  .append("circle")
+  .attr("cx", (d) => x(d.date))
+  .attr("cy", (d) => y(d.value))
+  .attr("r", 6)
+  .style("fill", color.chartLine);

--- a/gpt-summary/public/js/lineChartSummary.js
+++ b/gpt-summary/public/js/lineChartSummary.js
@@ -1,5 +1,6 @@
 // DO NOT commit your API token to GitHub
-const TOKEN = "YOUR_TOKEN_HERE";
+// Users will have to privde their own OpenAI token for the fetch call header.
+const TOKEN = "";
 
 const gptPrompt = {
   model: "gpt-3.5-turbo",

--- a/gpt-summary/public/js/lineChartSummary.js
+++ b/gpt-summary/public/js/lineChartSummary.js
@@ -8,7 +8,7 @@ const gptPrompt = {
     {
       role: "user",
       content:
-        "The following data is historical pricing information for Apple. Summarize the data for me. Jun 05, 2023 179.35 Jun 02, 2023 180.95 Jun 01, 2023 180.09 May 31, 2023 177.25 May 30, 2023 177.30 May 26, 2023 175.43 May 25, 2023 172.99 May 24, 2023 171.84 May 23, 2023 171.56 May 22, 2023 174.20 May 19, 2023 175.16 May 18, 2023 175.05 May 17, 2023 172.69 May 16, 2023 172.07 May 15, 2023 172.07 May 12, 2023 172.57",
+        "The following data is historical pricing information for Apple. Summarize the data for me. Please include high price, low price, and general trend. Jun 05, 2023 179.35 Jun 02, 2023 180.95 Jun 01, 2023 180.09 May 31, 2023 177.25 May 30, 2023 177.30 May 26, 2023 175.43 May 25, 2023 172.99 May 24, 2023 171.84 May 23, 2023 171.56 May 22, 2023 174.20 May 19, 2023 175.16 May 18, 2023 175.05 May 17, 2023 172.69 May 16, 2023 172.07 May 15, 2023 172.07 May 12, 2023 172.57",
     },
   ],
   temperature: 1.0,
@@ -27,7 +27,24 @@ const requestInit = {
 function handleSummaryAndAria(data, summaryId, chartId) {
   const chartContainer = document.getElementById(chartId);
   const summaryContainer = document.getElementById(summaryId);
+  const docFragment = new DocumentFragment();
+
+  // Summary nodes
+  const summaryParagraph = document.createElement("p");
   const summaryContent = data.choices[0].message.content;
+  summaryParagraph.append(summaryContent);
+
+  // AAPL stock link
+  const stockLinkParagraph = document.createElement("p");
+  const stockLink = document.createElement("a");
+  const stockLinkText = document.createTextNode("AAPL stock quote");
+  stockLink.setAttribute("href", "https://finance.yahoo.com/quote/AAPL/");
+  stockLink.append(stockLinkText);
+  stockLinkParagraph.append(stockLink);
+
+  docFragment.append(summaryParagraph);
+  docFragment.append(stockLinkParagraph);
+  summaryContainer.append(docFragment);
 
   chartContainer.setAttribute(
     "aria-label",
@@ -35,8 +52,6 @@ function handleSummaryAndAria(data, summaryId, chartId) {
   );
   chartContainer.setAttribute("aria-describedby", summaryId);
   chartContainer.setAttribute("tabindex", "0");
-
-  summaryContainer.append(summaryContent);
 }
 
 fetch("https://api.openai.com/v1/chat/completions", requestInit)
@@ -46,7 +61,11 @@ fetch("https://api.openai.com/v1/chat/completions", requestInit)
   })
   .then((data) => {
     console.log(data);
-    handleSummaryAndAria(data, "gpt-response-container", "d3-chart-container");
+    handleSummaryAndAria(
+      data,
+      "gpt-response-container",
+      "combined-chart-wrapper"
+    );
   })
   .catch((err) => {
     console.log(err);

--- a/gpt-summary/public/js/lineChartSummary.js
+++ b/gpt-summary/public/js/lineChartSummary.js
@@ -1,0 +1,53 @@
+// DO NOT commit your API token to GitHub
+const TOKEN = "YOUR_TOKEN_HERE";
+
+const gptPrompt = {
+  model: "gpt-3.5-turbo",
+  max_tokens: 512,
+  messages: [
+    {
+      role: "user",
+      content:
+        "The following data is historical pricing information for Apple. Summarize the data for me. Jun 05, 2023 179.35 Jun 02, 2023 180.95 Jun 01, 2023 180.09 May 31, 2023 177.25 May 30, 2023 177.30 May 26, 2023 175.43 May 25, 2023 172.99 May 24, 2023 171.84 May 23, 2023 171.56 May 22, 2023 174.20 May 19, 2023 175.16 May 18, 2023 175.05 May 17, 2023 172.69 May 16, 2023 172.07 May 15, 2023 172.07 May 12, 2023 172.57",
+    },
+  ],
+  temperature: 1.0,
+};
+
+const requestHeaders = new Headers();
+requestHeaders.append("Content-Type", "application/json");
+requestHeaders.append("Authorization", `Bearer ${TOKEN}`);
+
+const requestInit = {
+  method: "POST",
+  headers: requestHeaders,
+  body: JSON.stringify(gptPrompt),
+};
+
+function handleSummaryAndAria(data, summaryId, chartId) {
+  const chartContainer = document.getElementById(chartId);
+  const summaryContainer = document.getElementById(summaryId);
+  const summaryContent = data.choices[0].message.content;
+
+  chartContainer.setAttribute(
+    "aria-label",
+    "Apple stock price, last three weeks"
+  );
+  chartContainer.setAttribute("aria-describedby", summaryId);
+  chartContainer.setAttribute("tabindex", "0");
+
+  summaryContainer.append(summaryContent);
+}
+
+fetch("https://api.openai.com/v1/chat/completions", requestInit)
+  .then((response) => {
+    let data = response.json();
+    return data;
+  })
+  .then((data) => {
+    console.log(data);
+    handleSummaryAndAria(data, "gpt-response-container", "d3-chart-container");
+  })
+  .catch((err) => {
+    console.log(err);
+  });

--- a/gpt-summary/public/js/lineChartSummary.js
+++ b/gpt-summary/public/js/lineChartSummary.js
@@ -1,5 +1,5 @@
 // DO NOT commit your API token to GitHub
-// Users will have to privde their own OpenAI token for the fetch call header.
+// Users will have to provide their own OpenAI token for the fetch call header.
 const TOKEN = "";
 
 const gptPrompt = {


### PR DESCRIPTION
This PR adds the ChatGPT summary to the chart. The summary is a hard-coded text prompt that asks ChatGPT to summarize the chart data by high price, low price, and general trend.

The data used is accurate historical data for the Apple stock (AAPL).

PR closes #3.